### PR TITLE
REVIEW: get_sections()

### DIFF
--- a/R/get_columns.R
+++ b/R/get_columns.R
@@ -10,7 +10,7 @@
 #' @param unit_id \code{integer}. Filter columns to those containing unit(s) as
 #'   specified by their unique identification number(s).
 #' @param strat_name \code{character}. Filter columns to those containing a unit
-#'   that fuzzy matches a stratigraphic name (e.g., "Hell Creek").
+#'   that matches a stratigraphic name (e.g., "Hell Creek").
 #' @param strat_name_id \code{integer}. Filter columns to those containing a
 #'   unit that matches one or more stratigraphic name(s) as specified by their
 #'   unique identification number(s).
@@ -97,15 +97,15 @@
 #'   \item \code{col_type}: The type of column.
 #'   \item \code{refs}: The unique identification number(s) for the reference(s)
 #'     associated with the column.
-#'   \item \code{max_thick}: Maximum unit thickness in meters.
+#'   \item \code{max_thick}: The maximum unit thickness in meters.
 #'   \item \code{max_min_thick}: The maximum possible minimum thickness in
 #'     meters.
 #'   \item \code{min_min_thick}: The minimum possible minimum thickness in
 #'     meters.
-#'   \item \code{b_age}: The estimated bottom age of the column, in millions of
-#'     years before present.
-#'   \item \code{t_age}: The estimated top age of the column, in millions of
-#'     years before present.
+#'   \item \code{b_age}: The age of the bottom of the unit, estimated using the
+#'      continuous time age model, in millions of years before present.
+#'   \item \code{t_age}: The age of the top of the unit, estimated using the
+#'      continuous time age model, in millions of years before present.
 #'   \item \code{b_int_name}: The name of the time interval represented at the
 #'     bottom of the column.
 #'   \item \code{t_int_name}: The name of the time interval represented at the

--- a/R/get_columns.R
+++ b/R/get_columns.R
@@ -10,7 +10,7 @@
 #' @param unit_id \code{integer}. Filter columns to those containing unit(s) as
 #'   specified by their unique identification number(s).
 #' @param strat_name \code{character}. Filter columns to those containing a unit
-#'   that matches a stratigraphic name (e.g., "Hell Creek").
+#'   that fuzzy matches a stratigraphic name (e.g., "Hell Creek").
 #' @param strat_name_id \code{integer}. Filter columns to those containing a
 #'   unit that matches one or more stratigraphic name(s) as specified by their
 #'   unique identification number(s).
@@ -102,10 +102,10 @@
 #'     meters.
 #'   \item \code{min_min_thick}: The minimum possible minimum thickness in
 #'     meters.
-#'   \item \code{b_age}: The age of the bottom of the unit, estimated using the
-#'      continuous time age model, in millions of years before present.
-#'   \item \code{t_age}: The age of the top of the unit, estimated using the
-#'      continuous time age model, in millions of years before present.
+#'   \item \code{b_age}: The age of the bottom of the column, estimated using
+#'     the continuous time age model, in millions of years before present.
+#'   \item \code{t_age}: The age of the top of the column, estimated using the
+#'     continuous time age model, in millions of years before present.
 #'   \item \code{b_int_name}: The name of the time interval represented at the
 #'     bottom of the column.
 #'   \item \code{t_int_name}: The name of the time interval represented at the
@@ -143,7 +143,7 @@
 #'      \item \code{class}: The named economic attribute class (e.g., "precious
 #'        commodity").
 #'      \item \code{prop}: The proportion of the economic attribute out of
-#'        potential economic attributes contained within the column, calculated
+#'        all economic attributes contained within the column, calculated
 #'        from the individual Macrostrat units within the column.
 #'      \item \code{econ_id}: The unique identification number of the economic
 #'        attribute.
@@ -169,7 +169,7 @@
 #' ex2 <- get_columns(age_top = 200, age_bottom = 250)
 #' # Return columns that contain a specific stratigraphic unit, in `sf` format
 #' ex3 <- get_columns(strat_name = "mancos", sf = TRUE)
-#' # Return the columns surrounding a specific geographic coordinate
+#' # Return the columns at a specific geographic coordinate
 #' ex4 <- get_columns(lat = 43, lng = -89, adjacents = TRUE)
 #' }
 #' @export

--- a/R/get_sections.R
+++ b/R/get_sections.R
@@ -1,6 +1,8 @@
 #' @title Retrieve Macrostrat section data
+#'
 #' @description A function to retrieve Macrostrat units contained within
-#'   gap-bound packages.
+#'   gap-bound packages (sections).
+#'
 #' @param section_id \code{integer}. Filter sections by their unique
 #'   identification number(s).
 #' @param column_id \code{integer}. Filter sections to those contained within
@@ -8,7 +10,7 @@
 #' @param unit_id \code{integer}. Filter sections to those containing unit(s) as
 #'   specified by their unique identification number(s).
 #' @param strat_name \code{character}. Filter sections to those containing a
-#'   unit that fuzzy matches a stratigraphic name (e.g., "Hell Creek").
+#'   unit that matches a stratigraphic name (e.g., "Hell Creek").
 #' @param strat_name_id \code{integer}. Filter sections to those containing a
 #'   unit that matches one or more stratigraphic name(s) as specified by their
 #'   unique identification number(s).
@@ -31,10 +33,11 @@
 #'   degree latitude. Must also specify `lng`.
 #' @param lng \code{numeric}. Return the sections at the specified decimal
 #'   degree longitude. Must also specify `lat`.
-#' @param lithology \code{character}. Filter sections to those containing one or
-#'   more lithology(ies) (e.g., "shale", "sandstone").
+#' @param lithology \code{character}. Filter sections to those containing a
+#'   named lithology (e.g., "shale", "sandstone").
 #' @param lithology_id \code{integer}. Filter sections to those containing one
-#'   or more lithology(ies) identified by their unique identification number(s).
+#'   or more lithology(ies) as specified by their unique identification
+#'   number(s).
 #' @param lithology_group \code{character}. Filter sections to those containing
 #'   a named lithology group (e.g., "sandstones", "mudrocks", "unconsolidated").
 #' @param lithology_type \code{character}. Filter sections to those containing a
@@ -57,6 +60,9 @@
 #'   named environment type (e.g., "fluvial", "eolian", "glacial").
 #' @param environ_class \code{character}. Filter sections to those containing a
 #'   named environment class (e.g., "marine", "non-marine").
+#' @param pbdb_collection_no \code{integer}. Filter sections to those containing
+#'   one or more Paleobiology Database collection(s) as specified by their
+#'   unique identification number(s).
 #' @param econ \code{character}. Filter sections to those containing a named
 #'   economic attribute (e.g., "brick", "ground water", "gold").
 #' @param econ_id \code{integer}. Filter sections to those containing one or
@@ -67,81 +73,83 @@
 #' @param econ_class \code{character}. Filter sections to those containing a
 #'   named economic attribute class (e.g., "material", "water", "precious
 #'   commodity").
-#' @param pbdb_collection_no \code{integer}. Filter sections to those containing
-#'   one or more Paleobiology Database collection(s) as specified by their
-#'   unique identification number(s).
-#' @param project_id \code{integer}. Filter sections to those contained within a
-#'   Macrostrat project as specified by its unique identification number.
+#' @param project_id \code{integer}. Filter sections to those contained within
+#'   one or more Macrostrat project(s) as specified by their unique
+#'   identification number(s).
 #' @param adjacents \code{logical}. If `column_id` or `lat`/`lng` is specified,
 #'   should all sections that touch the specified column be returned? Defaults
 #'   to `FALSE`.
+#'
 #' @return A \code{dataframe} containing the following columns:
 #' \itemize{
-#'   \item \code{col_id}: The unique Macrostrat column identification number.
+#'   \item \code{col_id}: The unique identification number of the Macrostrat
+#'     column.
 #'   \item \code{col_area}: The area of the Macrostrat column in
-#'   km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
+#'     km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 #'   \item \code{section_id}: The unique identification number of the Macrostrat
-#'   section.
+#'     section.
 #'   \item \code{project_id}: The unique identification number of the Macrostrat
-#'   project.
-#'   \item \code{max_thick}: The maximum thickness within the focal region.
-#'   \item \code{min_thick}: The minimum thickness within the focal region.
-#'   \item \code{t_age}: The top age of the section, estimated using the
-#'   continuous time age model, in millions of years before present.
-#'   \item \code{b_age}: The bottom age of the section, estimated using the
-#'   continuous time age model, in millions of years before present.
+#'     project.
+#'   \item \code{max_thick}: The maximum thickness of the section, in meters.
+#'   \item \code{min_thick}: The minimum thickness of the section, in meters.
+#'   \item \code{t_age}: The age of the top of the section, estimated using the
+#'     continuous time age model, in millions of years before present.
+#'   \item \code{b_age}: The age of the bottom of the section, estimated using the
+#'     continuous time age model, in millions of years before present.
 #'   \item \code{pbdb_collections}: The number of PBDB collections contained
-#'   within the section.
+#'     within the section.
 #'   \item \code{lith}: a \code{dataframe} containing the lithologies present
-#'   within the section, with the following columns:
+#'     within the section, with the following columns:
 #'   \itemize{
 #'      \item \code{name}: The named lithology (e.g., "sandstone").
 #'      \item \code{type}: The named lithology type (e.g., "siliciclastic").
 #'      \item \code{class}: The named lithology class (e.g., "sedimentary").
 #'      \item \code{prop}: The proportion of the lithology within the section,
-#'      calculated from the individual Macrostrat units within the section.
+#'        calculated from the individual Macrostrat units within the section.
 #'      \item \code{lith_id}: The unique identification number of the lithology.
 #'   }}
 #'   \itemize{
-#'   \item \code{environ}: a \code{dataframe} containing the environments present
-#'   within the section, with the following columns:
+#'   \item \code{environ}: a \code{dataframe} containing the environments
+#'     present within the section, with the following columns:
 #'   \itemize{
 #'      \item \code{name}: The named environment (e.g., "delta plain").
 #'      \item \code{type}: The named environment type (e.g., "siliciclastic").
 #'      \item \code{class}: The named environment class (e.g., "marine").
 #'      \item \code{prop}: The proportion of the environment within the section,
-#'      calculated from the individual Macrostrat units within the section.
-#'      \item \code{environ_id}: The unique identification number of the environment.
+#'        calculated from the individual Macrostrat units within the section.
+#'      \item \code{environ_id}: The unique identification number of the
+#'        environment.
 #'   }}
 #'   \itemize{
 #'   \item \code{econ}: a \code{dataframe} containing the economic attributes
-#'   present within the section, with the following columns:
+#'     present within the section, with the following columns:
 #'   \itemize{
 #'      \item \code{name}: The named economic attribute (e.g., "gold").
 #'      \item \code{type}: The named economic attribute type (e.g., "mineral").
 #'      \item \code{class}: The named economic attribute class (e.g., "precious
-#'      commodity").
-#'      \item \code{prop}: The proportion of the economic attribute out of potential
-#'      economic attributes contained within the section, calculated from the
-#'      individual Macrostrat units within the section.
+#'        commodity").
+#'      \item \code{prop}: The proportion of the economic attribute out of
+#'        potential economic attributes contained within the section, calculated
+#'        from the individual Macrostrat units within the section.
 #'      \item \code{econ_id}: The unique identification number of the economic
-#'      attribute.
+#'        attribute.
 #'   }
 #' }
 #'
-#' @author Christopher D. Dean
+#' @section Developer(s):
+#'   Christopher D. Dean
+#' @section Reviewer(s):
+#'   Bethany Allen
+#'
 #' @details More information can be found for the inputs for this function
 #' using the definition functions (beginning with \code{defs_}).
+#'
 #' @examples
 #' \dontrun{
-#'   # get_sections(section_id = 1)
-#'   # get_sections(column_id = 10)
-#'   # head(get_sections(age = 73))
-#'   # head(get_sections(age_top = 70, age_bottom = 75))
-#'   # head(get_sections(lat = 45, lng = -100))
-#'   # head(get_sections(lithology = "sandstone"))
-#'   # head(get_sections(environ_type = "siliciclastic"))
-#'   # head(get_sections(pbdb_collection_no = c(1000:5000)))
+#' # Get sections within a specified column
+#' ex1 <- get_sections(column_id = 10)
+#' # Get sections within a specified latitude-longitude box
+#' ex2 <- get_sections(lng = -110.9, lat = 48.4)
 #' }
 #' @export
 #' @family macrostrat
@@ -155,8 +163,8 @@ get_sections <- function(section_id = NULL, column_id = NULL, unit_id = NULL,
     lithology_att_id = NULL, lithology_att_type = NULL,
     environ = NULL, environ_id = NULL, environ_type = NULL,
     environ_class = NULL,
-    econ = NULL, econ_id = NULL, econ_type = NULL, econ_class = NULL,
     pbdb_collection_no = NULL,
+    econ = NULL, econ_id = NULL, econ_type = NULL, econ_class = NULL,
     project_id = NULL, adjacents = NULL) {
 
   # Error handling
@@ -190,38 +198,21 @@ get_sections <- function(section_id = NULL, column_id = NULL, unit_id = NULL,
   args <- as.list(environment())
 
   # Check whether class of arguments is valid
-  ref <- list(
-    section_id = "integer",
-    column_id = "integer",
-    unit_id = "integer",
-    strat_name = "character",
-    strat_name_id = "integer",
-    interval_name = "character",
-    interval_id = "integer",
-    age = "numeric",
-    age_top = "numeric",
-    age_bottom = "numeric",
-    lat = "numeric",
-    lng = "numeric",
-    lithology = "character",
-    lithology_id = "integer",
-    lithology_group = "character",
-    lithology_type = "character",
-    lithology_class = "character",
-    lithology_att = "character",
-    lithology_att_id = "integer",
-    lithology_att_type = "character",
-    environ = "character",
-    environ_id = "integer",
-    environ_type = "character",
-    environ_class = "character",
-    econ = "character",
-    econ_id = "integer",
-    econ_type = "character",
-    econ_class = "character",
-    pbdb_collection_no = "integer",
-    project_id = "integer",
-    adjacents = "logical"
+  ref <- list(section_id = "integer", column_id = "integer",
+              unit_id = "integer", strat_name = "character",
+              strat_name_id = "integer", interval_name = "character",
+              interval_id = "integer", age = "numeric", age_top = "numeric",
+              age_bottom = "numeric", lat = "numeric", lng = "numeric",
+              lithology = "character", lithology_id = "integer",
+              lithology_group = "character", lithology_type = "character",
+              lithology_class = "character", lithology_att = "character",
+              lithology_att_id = "integer", lithology_att_type = "character",
+              environ = "character", environ_id = "integer",
+              environ_type = "character", environ_class = "character",
+              pbdb_collection_no = "integer", econ = "character",
+              econ_id = "integer", econ_type = "character",
+              econ_class = "character", project_id = "integer",
+              adjacents = "logical"
   )
   check_arguments(x = args, ref = ref)
 

--- a/R/get_sections.R
+++ b/R/get_sections.R
@@ -10,7 +10,7 @@
 #' @param unit_id \code{integer}. Filter sections to those containing unit(s) as
 #'   specified by their unique identification number(s).
 #' @param strat_name \code{character}. Filter sections to those containing a
-#'   unit that matches a stratigraphic name (e.g., "Hell Creek").
+#'   unit that fuzzy matches a stratigraphic name (e.g., "Hell Creek").
 #' @param strat_name_id \code{integer}. Filter sections to those containing a
 #'   unit that matches one or more stratigraphic name(s) as specified by their
 #'   unique identification number(s).
@@ -83,8 +83,8 @@
 #' @return A \code{dataframe} containing the following columns:
 #' \itemize{
 #'   \item \code{col_id}: The unique identification number of the Macrostrat
-#'     column.
-#'   \item \code{col_area}: The area of the Macrostrat column in
+#'     column containing the section.
+#'   \item \code{col_area}: The area of the associated Macrostrat column in
 #'     km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 #'   \item \code{section_id}: The unique identification number of the Macrostrat
 #'     section.
@@ -94,8 +94,8 @@
 #'   \item \code{min_thick}: The minimum thickness of the section, in meters.
 #'   \item \code{t_age}: The age of the top of the section, estimated using the
 #'     continuous time age model, in millions of years before present.
-#'   \item \code{b_age}: The age of the bottom of the section, estimated using the
-#'     continuous time age model, in millions of years before present.
+#'   \item \code{b_age}: The age of the bottom of the section, estimated using
+#'     the continuous time age model, in millions of years before present.
 #'   \item \code{pbdb_collections}: The number of PBDB collections contained
 #'     within the section.
 #'   \item \code{lith}: a \code{dataframe} containing the lithologies present
@@ -129,7 +129,7 @@
 #'      \item \code{class}: The named economic attribute class (e.g., "precious
 #'        commodity").
 #'      \item \code{prop}: The proportion of the economic attribute out of
-#'        potential economic attributes contained within the section, calculated
+#'        all economic attributes contained within the section, calculated
 #'        from the individual Macrostrat units within the section.
 #'      \item \code{econ_id}: The unique identification number of the economic
 #'        attribute.
@@ -148,7 +148,7 @@
 #' \dontrun{
 #' # Get sections within a specified column
 #' ex1 <- get_sections(column_id = 10)
-#' # Get sections within a specified latitude-longitude box
+#' # Get sections at a specific geographic coordinate
 #' ex2 <- get_sections(lng = -110.9, lat = 48.4)
 #' }
 #' @export
@@ -165,7 +165,7 @@ get_sections <- function(section_id = NULL, column_id = NULL, unit_id = NULL,
     environ_class = NULL,
     pbdb_collection_no = NULL,
     econ = NULL, econ_id = NULL, econ_type = NULL, econ_class = NULL,
-    project_id = NULL, adjacents = NULL) {
+    project_id = NULL, adjacents = FALSE) {
 
   # Error handling
   # Check specific argument constraints

--- a/R/get_units.R
+++ b/R/get_units.R
@@ -10,7 +10,7 @@
 #' @param column_id \code{integer}. Filter units to those contained within
 #'   column(s) as specified by their unique identification number(s).
 #' @param strat_name \code{character}. Filter units to those containing a unit
-#'   that matches a stratigraphic name (e.g., "Hell Creek").
+#'   that fuzzy matches a stratigraphic name (e.g., "Hell Creek").
 #' @param strat_name_id \code{integer}. Filter units to those that match one
 #'   or more stratigraphic name(s) as specified by their unique identification
 #'   number(s).
@@ -88,12 +88,12 @@
 #'    \item \code{unit_id}: The unique identification number of the Macrostrat
 #'      unit.
 #'    \item \code{section_id}: The unique identification number of the
-#'      Macrostrat section.
+#'      Macrostrat section containing the unit.
 #'    \item \code{col_id}: The unique identification number of the Macrostrat
-#'      column.
+#'      column containing the unit.
 #'    \item \code{project_id}: The unique identification number of the
 #'      Macrostrat project.
-#'    \item \code{col_area}: The area of the Macrostrat column in
+#'    \item \code{col_area}: The area of the associated Macrostrat column in
 #'      km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 #'    \item \code{unit_name}: The name of the Macrostrat unit.
 #'    \item \code{strat_name_id}: The unique Macrostrat stratigraphic name ID.
@@ -209,7 +209,7 @@
 #' \dontrun{
 #' # Get units with a specific stratigraphic name
 #' ex1 <- get_units(strat_name = "Hell Creek")
-#' # Get units within a specified latitude-longitude box
+#' # Get units at a specific geographic coordinate
 #' ex2 <- get_units(lng = -110.9, lat = 48.4)
 #' }
 #' @export
@@ -226,7 +226,7 @@ get_units <- function(unit_id = NULL, section_id = NULL, column_id = NULL,
                       environ = NULL, environ_id = NULL, environ_type = NULL,
                       environ_class = NULL, pbdb_collection_no = NULL,
                       econ = NULL, econ_id = NULL, econ_type = NULL,
-                      econ_class = NULL, project_id = NULL, adjacents = NULL,
+                      econ_class = NULL, project_id = NULL, adjacents = FALSE,
                       sf = FALSE) {
   # Error handling
   # Collect input arguments as a list

--- a/R/get_units.R
+++ b/R/get_units.R
@@ -74,21 +74,25 @@
 #' @param econ_class \code{character}. Filter units to those containing a
 #'   named economic attribute class (e.g., "material", "water", "precious
 #'   commodity").
-#' @param adjacents \code{logical}. If `column_id` or `lat`/`lng` is
-#'   specified, should all units that touch the specified column be returned?
-#'   Defaults to `FALSE`.
 #' @param project_id \code{integer}. Filter units to those contained within
 #'   one or more Macrostrat project(s) as specified by their unique
 #'   identification number(s).
+#' @param adjacents \code{logical}. If `column_id` or `lat`/`lng` is
+#'   specified, should all units that touch the specified column be returned?
+#'   Defaults to `FALSE`.
 #' @param sf \code{logical}. Should the results be returned as an `sf` object?
 #'   Defaults to `FALSE`.
 #'
 #' @return A \code{data.frame} containing the following columns:
 #' \itemize{
-#'    \item \code{unit_id}: The unique Macrostrat unit ID.
-#'    \item \code{section_id}: The unique Macrostrat section ID.
-#'    \item \code{col_id}: The unique Macrostrat column ID.
-#'    \item \code{project_id}: The unique Macrostrat project ID.
+#'    \item \code{unit_id}: The unique identification number of the Macrostrat
+#'      unit.
+#'    \item \code{section_id}: The unique identification number of the
+#'      Macrostrat section.
+#'    \item \code{col_id}: The unique identification number of the Macrostrat
+#'      column.
+#'    \item \code{project_id}: The unique identification number of the
+#'      Macrostrat project.
 #'    \item \code{col_area}: The area of the Macrostrat column in
 #'      km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 #'    \item \code{unit_name}: The name of the Macrostrat unit.
@@ -97,18 +101,18 @@
 #'    \item \code{Fm}: The lithostratigraphic formation.
 #'    \item \code{Gp}: The lithostratigraphic group.
 #'    \item \code{SGp}: The lithostratigraphic supergroup.
-#'    \item \code{t_age}: Estimated top age based on continuous time age model
-#'      in millions of years before present.
-#'    \item \code{b_age}: Estimated bottom age based on continuous time age
-#'      model in millions of years before present.
-#'    \item \code{max_thick}: Maximum unit thickness in meters.
-#'    \item \code{min_thick}: Minimum unit thickness in meters.
+#'    \item \code{t_age}: The age of the top of the unit, estimated using the
+#'      continuous time age model, in millions of years before present.
+#'    \item \code{b_age}: The age of the bottom of the unit, estimated using the
+#'      continuous time age model, in millions of years before present.
+#'    \item \code{max_thick}: The maximum thickness of the unit, in meters.
+#'    \item \code{min_thick}: The minimum thickness of the unit, in meters.
 #'    \item \code{outcrop}: Type of exposure ("outcrop", "subsurface", or
 #'      "both").
-#'    \item \code{pbdb_collections}: Count of Paleobiology Database
-#'      collections within the unit.
-#'    \item \code{pbdb_occurrences}: Count of Paleobiology Database
-#'      occurrences within the unit.
+#'    \item \code{pbdb_collections}: The number of Paleobiology Database
+#'      collections contained within the unit.
+#'    \item \code{pbdb_occurrences}: The number of Paleobiology Database
+#'      occurrences contained within the unit.
 #'    \item \code{lith}: a \code{dataframe} containing the lithologies present
 #'      within the unit, with the following columns:
 #'      \itemize{
@@ -203,9 +207,9 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Get units by stratigraphic name
+#' # Get units with a specific stratigraphic name
 #' ex1 <- get_units(strat_name = "Hell Creek")
-#' # Get units by geographic coordinates
+#' # Get units within a specified latitude-longitude box
 #' ex2 <- get_units(lng = -110.9, lat = 48.4)
 #' }
 #' @export
@@ -222,7 +226,7 @@ get_units <- function(unit_id = NULL, section_id = NULL, column_id = NULL,
                       environ = NULL, environ_id = NULL, environ_type = NULL,
                       environ_class = NULL, pbdb_collection_no = NULL,
                       econ = NULL, econ_id = NULL, econ_type = NULL,
-                      econ_class = NULL, adjacents = NULL, project_id = NULL,
+                      econ_class = NULL, project_id = NULL, adjacents = NULL,
                       sf = FALSE) {
   # Error handling
   # Collect input arguments as a list
@@ -241,8 +245,8 @@ get_units <- function(unit_id = NULL, section_id = NULL, column_id = NULL,
               environ_type = "character", environ_class = "character",
               pbdb_collection_no = "integer", econ = "character",
               econ_id = "integer", econ_type = "character",
-              econ_class = "character", adjacents = "logical",
-              project_id = "integer", sf = "logical")
+              econ_class = "character", project_id = "integer",
+              adjacents = "logical", sf = "logical")
   # Check arguments
   check_arguments(x = args, ref = ref)
   # Check specific argument constraints

--- a/man/get_columns.Rd
+++ b/man/get_columns.Rd
@@ -49,7 +49,7 @@ section(s) as specified by their unique identification number(s).}
 specified by their unique identification number(s).}
 
 \item{strat_name}{\code{character}. Filter columns to those containing a unit
-that matches a stratigraphic name (e.g., "Hell Creek").}
+that fuzzy matches a stratigraphic name (e.g., "Hell Creek").}
 
 \item{strat_name_id}{\code{integer}. Filter columns to those containing a
 unit that matches one or more stratigraphic name(s) as specified by their
@@ -170,9 +170,9 @@ associated with the column.
 meters.
 \item \code{min_min_thick}: The minimum possible minimum thickness in
 meters.
-\item \code{b_age}: The age of the bottom of the unit, estimated using the
-continuous time age model, in millions of years before present.
-\item \code{t_age}: The age of the top of the unit, estimated using the
+\item \code{b_age}: The age of the bottom of the column, estimated using
+the continuous time age model, in millions of years before present.
+\item \code{t_age}: The age of the top of the column, estimated using the
 continuous time age model, in millions of years before present.
 \item \code{b_int_name}: The name of the time interval represented at the
 bottom of the column.
@@ -211,7 +211,7 @@ present within the column, with the following columns:
 \item \code{class}: The named economic attribute class (e.g., "precious
 commodity").
 \item \code{prop}: The proportion of the economic attribute out of
-potential economic attributes contained within the column, calculated
+all economic attributes contained within the column, calculated
 from the individual Macrostrat units within the column.
 \item \code{econ_id}: The unique identification number of the economic
 attribute.
@@ -250,7 +250,7 @@ ex1 <- get_columns(interval_name = "Permian")
 ex2 <- get_columns(age_top = 200, age_bottom = 250)
 # Return columns that contain a specific stratigraphic unit, in `sf` format
 ex3 <- get_columns(strat_name = "mancos", sf = TRUE)
-# Return the columns surrounding a specific geographic coordinate
+# Return the columns at a specific geographic coordinate
 ex4 <- get_columns(lat = 43, lng = -89, adjacents = TRUE)
 }
 }

--- a/man/get_columns.Rd
+++ b/man/get_columns.Rd
@@ -49,7 +49,7 @@ section(s) as specified by their unique identification number(s).}
 specified by their unique identification number(s).}
 
 \item{strat_name}{\code{character}. Filter columns to those containing a unit
-that fuzzy matches a stratigraphic name (e.g., "Hell Creek").}
+that matches a stratigraphic name (e.g., "Hell Creek").}
 
 \item{strat_name_id}{\code{integer}. Filter columns to those containing a
 unit that matches one or more stratigraphic name(s) as specified by their
@@ -165,15 +165,15 @@ Corresponds to general geographic region.
 \item \code{col_type}: The type of column.
 \item \code{refs}: The unique identification number(s) for the reference(s)
 associated with the column.
-\item \code{max_thick}: Maximum unit thickness in meters.
+\item \code{max_thick}: The maximum unit thickness in meters.
 \item \code{max_min_thick}: The maximum possible minimum thickness in
 meters.
 \item \code{min_min_thick}: The minimum possible minimum thickness in
 meters.
-\item \code{b_age}: The estimated bottom age of the column, in millions of
-years before present.
-\item \code{t_age}: The estimated top age of the column, in millions of
-years before present.
+\item \code{b_age}: The age of the bottom of the unit, estimated using the
+continuous time age model, in millions of years before present.
+\item \code{t_age}: The age of the top of the unit, estimated using the
+continuous time age model, in millions of years before present.
 \item \code{b_int_name}: The name of the time interval represented at the
 bottom of the column.
 \item \code{t_int_name}: The name of the time interval represented at the

--- a/man/get_sections.Rd
+++ b/man/get_sections.Rd
@@ -35,7 +35,7 @@ get_sections(
   econ_type = NULL,
   econ_class = NULL,
   project_id = NULL,
-  adjacents = NULL
+  adjacents = FALSE
 )
 }
 \arguments{
@@ -49,7 +49,7 @@ column(s) as specified by their unique identification number(s).}
 specified by their unique identification number(s).}
 
 \item{strat_name}{\code{character}. Filter sections to those containing a
-unit that matches a stratigraphic name (e.g., "Hell Creek").}
+unit that fuzzy matches a stratigraphic name (e.g., "Hell Creek").}
 
 \item{strat_name_id}{\code{integer}. Filter sections to those containing a
 unit that matches one or more stratigraphic name(s) as specified by their
@@ -150,8 +150,8 @@ to \code{FALSE}.}
 A \code{dataframe} containing the following columns:
 \itemize{
 \item \code{col_id}: The unique identification number of the Macrostrat
-column.
-\item \code{col_area}: The area of the Macrostrat column in
+column containing the section.
+\item \code{col_area}: The area of the associated Macrostrat column in
 km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 \item \code{section_id}: The unique identification number of the Macrostrat
 section.
@@ -161,8 +161,8 @@ project.
 \item \code{min_thick}: The minimum thickness of the section, in meters.
 \item \code{t_age}: The age of the top of the section, estimated using the
 continuous time age model, in millions of years before present.
-\item \code{b_age}: The age of the bottom of the section, estimated using the
-continuous time age model, in millions of years before present.
+\item \code{b_age}: The age of the bottom of the section, estimated using
+the continuous time age model, in millions of years before present.
 \item \code{pbdb_collections}: The number of PBDB collections contained
 within the section.
 \item \code{lith}: a \code{dataframe} containing the lithologies present
@@ -196,7 +196,7 @@ present within the section, with the following columns:
 \item \code{class}: The named economic attribute class (e.g., "precious
 commodity").
 \item \code{prop}: The proportion of the economic attribute out of
-potential economic attributes contained within the section, calculated
+all economic attributes contained within the section, calculated
 from the individual Macrostrat units within the section.
 \item \code{econ_id}: The unique identification number of the economic
 attribute.
@@ -225,7 +225,7 @@ Bethany Allen
 \dontrun{
 # Get sections within a specified column
 ex1 <- get_sections(column_id = 10)
-# Get sections within a specified latitude-longitude box
+# Get sections at a specific geographic coordinate
 ex2 <- get_sections(lng = -110.9, lat = 48.4)
 }
 }

--- a/man/get_sections.Rd
+++ b/man/get_sections.Rd
@@ -29,11 +29,11 @@ get_sections(
   environ_id = NULL,
   environ_type = NULL,
   environ_class = NULL,
+  pbdb_collection_no = NULL,
   econ = NULL,
   econ_id = NULL,
   econ_type = NULL,
   econ_class = NULL,
-  pbdb_collection_no = NULL,
   project_id = NULL,
   adjacents = NULL
 )
@@ -49,7 +49,7 @@ column(s) as specified by their unique identification number(s).}
 specified by their unique identification number(s).}
 
 \item{strat_name}{\code{character}. Filter sections to those containing a
-unit that fuzzy matches a stratigraphic name (e.g., "Hell Creek").}
+unit that matches a stratigraphic name (e.g., "Hell Creek").}
 
 \item{strat_name_id}{\code{integer}. Filter sections to those containing a
 unit that matches one or more stratigraphic name(s) as specified by their
@@ -81,11 +81,12 @@ degree latitude. Must also specify \code{lng}.}
 \item{lng}{\code{numeric}. Return the sections at the specified decimal
 degree longitude. Must also specify \code{lat}.}
 
-\item{lithology}{\code{character}. Filter sections to those containing one or
-more lithology(ies) (e.g., "shale", "sandstone").}
+\item{lithology}{\code{character}. Filter sections to those containing a
+named lithology (e.g., "shale", "sandstone").}
 
 \item{lithology_id}{\code{integer}. Filter sections to those containing one
-or more lithology(ies) identified by their unique identification number(s).}
+or more lithology(ies) as specified by their unique identification
+number(s).}
 
 \item{lithology_group}{\code{character}. Filter sections to those containing
 a named lithology group (e.g., "sandstones", "mudrocks", "unconsolidated").}
@@ -119,6 +120,10 @@ named environment type (e.g., "fluvial", "eolian", "glacial").}
 \item{environ_class}{\code{character}. Filter sections to those containing a
 named environment class (e.g., "marine", "non-marine").}
 
+\item{pbdb_collection_no}{\code{integer}. Filter sections to those containing
+one or more Paleobiology Database collection(s) as specified by their
+unique identification number(s).}
+
 \item{econ}{\code{character}. Filter sections to those containing a named
 economic attribute (e.g., "brick", "ground water", "gold").}
 
@@ -133,12 +138,9 @@ named economic attribute type (e.g., "construction", "aquifer", "mineral").}
 named economic attribute class (e.g., "material", "water", "precious
 commodity").}
 
-\item{pbdb_collection_no}{\code{integer}. Filter sections to those containing
-one or more Paleobiology Database collection(s) as specified by their
-unique identification number(s).}
-
-\item{project_id}{\code{integer}. Filter sections to those contained within a
-Macrostrat project as specified by its unique identification number.}
+\item{project_id}{\code{integer}. Filter sections to those contained within
+one or more Macrostrat project(s) as specified by their unique
+identification number(s).}
 
 \item{adjacents}{\code{logical}. If \code{column_id} or \code{lat}/\code{lng} is specified,
 should all sections that touch the specified column be returned? Defaults
@@ -147,18 +149,19 @@ to \code{FALSE}.}
 \value{
 A \code{dataframe} containing the following columns:
 \itemize{
-\item \code{col_id}: The unique Macrostrat column identification number.
+\item \code{col_id}: The unique identification number of the Macrostrat
+column.
 \item \code{col_area}: The area of the Macrostrat column in
 km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 \item \code{section_id}: The unique identification number of the Macrostrat
 section.
 \item \code{project_id}: The unique identification number of the Macrostrat
 project.
-\item \code{max_thick}: The maximum thickness within the focal region.
-\item \code{min_thick}: The minimum thickness within the focal region.
-\item \code{t_age}: The top age of the section, estimated using the
+\item \code{max_thick}: The maximum thickness of the section, in meters.
+\item \code{min_thick}: The minimum thickness of the section, in meters.
+\item \code{t_age}: The age of the top of the section, estimated using the
 continuous time age model, in millions of years before present.
-\item \code{b_age}: The bottom age of the section, estimated using the
+\item \code{b_age}: The age of the bottom of the section, estimated using the
 continuous time age model, in millions of years before present.
 \item \code{pbdb_collections}: The number of PBDB collections contained
 within the section.
@@ -173,15 +176,16 @@ calculated from the individual Macrostrat units within the section.
 \item \code{lith_id}: The unique identification number of the lithology.
 }}
 \itemize{
-\item \code{environ}: a \code{dataframe} containing the environments present
-within the section, with the following columns:
+\item \code{environ}: a \code{dataframe} containing the environments
+present within the section, with the following columns:
 \itemize{
 \item \code{name}: The named environment (e.g., "delta plain").
 \item \code{type}: The named environment type (e.g., "siliciclastic").
 \item \code{class}: The named environment class (e.g., "marine").
 \item \code{prop}: The proportion of the environment within the section,
 calculated from the individual Macrostrat units within the section.
-\item \code{environ_id}: The unique identification number of the environment.
+\item \code{environ_id}: The unique identification number of the
+environment.
 }}
 \itemize{
 \item \code{econ}: a \code{dataframe} containing the economic attributes
@@ -191,9 +195,9 @@ present within the section, with the following columns:
 \item \code{type}: The named economic attribute type (e.g., "mineral").
 \item \code{class}: The named economic attribute class (e.g., "precious
 commodity").
-\item \code{prop}: The proportion of the economic attribute out of potential
-economic attributes contained within the section, calculated from the
-individual Macrostrat units within the section.
+\item \code{prop}: The proportion of the economic attribute out of
+potential economic attributes contained within the section, calculated
+from the individual Macrostrat units within the section.
 \item \code{econ_id}: The unique identification number of the economic
 attribute.
 }
@@ -201,22 +205,28 @@ attribute.
 }
 \description{
 A function to retrieve Macrostrat units contained within
-gap-bound packages.
+gap-bound packages (sections).
 }
 \details{
 More information can be found for the inputs for this function
 using the definition functions (beginning with \code{defs_}).
 }
+\section{Developer(s)}{
+
+Christopher D. Dean
+}
+
+\section{Reviewer(s)}{
+
+Bethany Allen
+}
+
 \examples{
 \dontrun{
-  # get_sections(section_id = 1)
-  # get_sections(column_id = 10)
-  # head(get_sections(age = 73))
-  # head(get_sections(age_top = 70, age_bottom = 75))
-  # head(get_sections(lat = 45, lng = -100))
-  # head(get_sections(lithology = "sandstone"))
-  # head(get_sections(environ_type = "siliciclastic"))
-  # head(get_sections(pbdb_collection_no = c(1000:5000)))
+# Get sections within a specified column
+ex1 <- get_sections(column_id = 10)
+# Get sections within a specified latitude-longitude box
+ex2 <- get_sections(lng = -110.9, lat = 48.4)
 }
 }
 \seealso{
@@ -225,8 +235,5 @@ Macrostrat data entities:
 \code{\link{get_age_model}()},
 \code{\link{get_columns}()},
 \code{\link{get_units}()}
-}
-\author{
-Christopher D. Dean
 }
 \concept{macrostrat}

--- a/man/get_units.Rd
+++ b/man/get_units.Rd
@@ -34,8 +34,8 @@ get_units(
   econ_id = NULL,
   econ_type = NULL,
   econ_class = NULL,
-  adjacents = NULL,
   project_id = NULL,
+  adjacents = NULL,
   sf = FALSE
 )
 }
@@ -140,13 +140,13 @@ economic attribute type (e.g., "construction", "aquifer", "mineral").}
 named economic attribute class (e.g., "material", "water", "precious
 commodity").}
 
-\item{adjacents}{\code{logical}. If \code{column_id} or \code{lat}/\code{lng} is
-specified, should all units that touch the specified column be returned?
-Defaults to \code{FALSE}.}
-
 \item{project_id}{\code{integer}. Filter units to those contained within
 one or more Macrostrat project(s) as specified by their unique
 identification number(s).}
+
+\item{adjacents}{\code{logical}. If \code{column_id} or \code{lat}/\code{lng} is
+specified, should all units that touch the specified column be returned?
+Defaults to \code{FALSE}.}
 
 \item{sf}{\code{logical}. Should the results be returned as an \code{sf} object?
 Defaults to \code{FALSE}.}
@@ -154,10 +154,14 @@ Defaults to \code{FALSE}.}
 \value{
 A \code{data.frame} containing the following columns:
 \itemize{
-\item \code{unit_id}: The unique Macrostrat unit ID.
-\item \code{section_id}: The unique Macrostrat section ID.
-\item \code{col_id}: The unique Macrostrat column ID.
-\item \code{project_id}: The unique Macrostrat project ID.
+\item \code{unit_id}: The unique identification number of the Macrostrat
+unit.
+\item \code{section_id}: The unique identification number of the
+Macrostrat section.
+\item \code{col_id}: The unique identification number of the Macrostrat
+column.
+\item \code{project_id}: The unique identification number of the
+Macrostrat project.
 \item \code{col_area}: The area of the Macrostrat column in
 km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 \item \code{unit_name}: The name of the Macrostrat unit.
@@ -166,18 +170,18 @@ km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 \item \code{Fm}: The lithostratigraphic formation.
 \item \code{Gp}: The lithostratigraphic group.
 \item \code{SGp}: The lithostratigraphic supergroup.
-\item \code{t_age}: Estimated top age based on continuous time age model
-in millions of years before present.
-\item \code{b_age}: Estimated bottom age based on continuous time age
-model in millions of years before present.
-\item \code{max_thick}: Maximum unit thickness in meters.
-\item \code{min_thick}: Minimum unit thickness in meters.
+\item \code{t_age}: The age of the top of the unit, estimated using the
+continuous time age model, in millions of years before present.
+\item \code{b_age}: The age of the bottom of the unit, estimated using the
+continuous time age model, in millions of years before present.
+\item \code{max_thick}: The maximum thickness of the unit, in meters.
+\item \code{min_thick}: The minimum thickness of the unit, in meters.
 \item \code{outcrop}: Type of exposure ("outcrop", "subsurface", or
 "both").
-\item \code{pbdb_collections}: Count of Paleobiology Database
-collections within the unit.
-\item \code{pbdb_occurrences}: Count of Paleobiology Database
-occurrences within the unit.
+\item \code{pbdb_collections}: The number of Paleobiology Database
+collections contained within the unit.
+\item \code{pbdb_occurrences}: The number of Paleobiology Database
+occurrences contained within the unit.
 \item \code{lith}: a \code{dataframe} containing the lithologies present
 within the unit, with the following columns:
 \itemize{
@@ -282,9 +286,9 @@ William Gearty
 
 \examples{
 \dontrun{
-# Get units by stratigraphic name
+# Get units with a specific stratigraphic name
 ex1 <- get_units(strat_name = "Hell Creek")
-# Get units by geographic coordinates
+# Get units within a specified latitude-longitude box
 ex2 <- get_units(lng = -110.9, lat = 48.4)
 }
 }

--- a/man/get_units.Rd
+++ b/man/get_units.Rd
@@ -35,7 +35,7 @@ get_units(
   econ_type = NULL,
   econ_class = NULL,
   project_id = NULL,
-  adjacents = NULL,
+  adjacents = FALSE,
   sf = FALSE
 )
 }
@@ -50,7 +50,7 @@ section(s) as specified by their unique identification number(s).}
 column(s) as specified by their unique identification number(s).}
 
 \item{strat_name}{\code{character}. Filter units to those containing a unit
-that matches a stratigraphic name (e.g., "Hell Creek").}
+that fuzzy matches a stratigraphic name (e.g., "Hell Creek").}
 
 \item{strat_name_id}{\code{integer}. Filter units to those that match one
 or more stratigraphic name(s) as specified by their unique identification
@@ -157,12 +157,12 @@ A \code{data.frame} containing the following columns:
 \item \code{unit_id}: The unique identification number of the Macrostrat
 unit.
 \item \code{section_id}: The unique identification number of the
-Macrostrat section.
+Macrostrat section containing the unit.
 \item \code{col_id}: The unique identification number of the Macrostrat
-column.
+column containing the unit.
 \item \code{project_id}: The unique identification number of the
 Macrostrat project.
-\item \code{col_area}: The area of the Macrostrat column in
+\item \code{col_area}: The area of the associated Macrostrat column in
 km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}.
 \item \code{unit_name}: The name of the Macrostrat unit.
 \item \code{strat_name_id}: The unique Macrostrat stratigraphic name ID.
@@ -288,7 +288,7 @@ William Gearty
 \dontrun{
 # Get units with a specific stratigraphic name
 ex1 <- get_units(strat_name = "Hell Creek")
-# Get units within a specified latitude-longitude box
+# Get units at a specific geographic coordinate
 ex2 <- get_units(lng = -110.9, lat = 48.4)
 }
 }


### PR DESCRIPTION
Hi all, as this is the final one of the big three functions to be reviewed, I also tried to get them to align a little better. As such I changed some of the phrasing of the definitions so they match. A few things it would be good to discuss:
* Do we want to thoroughly check consistency between these three functions, or is it fine as long as they have all been reviewed?
* I reordered a couple of the arguments so that these match (according to what we agreed at the end of the week, I think). Are we happy with this?
* The current description of `econ$prop` in the returned `df` is a bit awkward. Is this the proportion of the section/column thought to contain the specific resource?
* Do we want to align the examples? I think we should at least have the same number of examples for each.