### PR TITLE
REVIEW: def_drilling_sites()

### DIFF
--- a/R/def_drilling_sites.R
+++ b/R/def_drilling_sites.R
@@ -54,7 +54,7 @@
 #' # Return all core information for a specific site
 #' core_info <- def_drilling_sites(site = "U1547")
 #' # Return all core information for a specific expedition
-#' core_info <- def_drilling_sites(exp = "385")
+#' core_info <- def_drilling_sites(exp = "317")
 #' }
 #' @export
 #' @family external

--- a/R/def_drilling_sites.R
+++ b/R/def_drilling_sites.R
@@ -53,8 +53,6 @@
 #' \dontrun{
 #' # Return all core information for a specific site
 #' core_info <- def_drilling_sites(site = "U1547")
-#' # Return all core information for a specific expedition
-#' core_info <- def_drilling_sites(exp = "317")
 #' }
 #' @export
 #' @family external

--- a/R/def_drilling_sites.R
+++ b/R/def_drilling_sites.R
@@ -1,4 +1,5 @@
 #' @title Define objects associated with eODP
+#'
 #' @description Obtain metadata for variables associated with the
 #' [Extending Ocean Drilling Pursuits (eODP)](https://eodp.github.io) project.
 #' By default, data for all drilling sites are returned.
@@ -6,38 +7,42 @@
 #' @param program \code{character}. The name of a drilling program (i.e.,
 #'   "DSDP", "ODP", or "IODP") to return a definition for.
 #' @param exp \code{character}. The unique identification number(s) of drilling
-#'   leg(s) to return a definition for.
+#'   expedition(s) to return a definition for (formerly known as 'leg(s)').
 #' @param site \code{character}. The unique identification number(s) of drilling
 #'   site(s) to return a definition for.
 #' @param sf \code{logical}. Should the results be returned as an `sf` object?
-#' Defaults to `FALSE`.
+#'   Defaults to `FALSE`.
 #'
 #' @return A \code{data.frame} object containing, for each retrieved core:
 #' \itemize{
 #'  \item \code{epoch}: The name of the drilling program.
-#'  \item \code{exp}: The name of the leg/expedition.
+#'  \item \code{leg}: The name of the expedition (formerly known as a 'leg').
 #'  \item \code{site}: The name of the drilling site.
 #'  \item \code{hole}: The name of the drilling hole.
-#'  \item \code{lat}: Decimal degree latitude of the core.
-#'  \item \code{lng}: Decimal degree longitude of the core.
-#'  \item \code{col_id}: The unique identifier of the Macrostrat column.
-#'  \item \code{col_group_id}: The unique identifier of the group to which the
-#'    Macrostrat column belongs.
-#'  \item \code{penetration}: The depth of the hole.
-#'  \item \code{cored}: The amount of rock cored.
-#'  \item \code{recovered}: The amount of rock recovered.
-#'  \item \code{recovery}: The proportion of rock recovered.
+#'  \item \code{lat}: The decimal degree latitude of the drilling hole.
+#'  \item \code{lng}: The decimal degree longitude of the drilling hole.
+#'  \item \code{col_id}: The unique identification number of the eODP column.
+#'  \item \code{col_group_id}: The unique identification number of the group to
+#'    which the eODP column belongs.
+#'  \item \code{penetration}: The depth of the hole drilled, in meters.
+#'  \item \code{cored}: The amount of rock cored from the drill hole, in meters.
+#'  \item \code{recovered}: The amount of rock recovered from the core, in
+#'    meters.
+#'  \item \code{recovery}: The proportion of rock recovered from the core.
 #'  \item \code{drilled_interval}: The interval drilled.
 #'  \item \code{drilled_intervals}: The number of drilled intervals.
-#'  \item \code{cores}: The number of cores.
+#'  \item \code{cores}: The total number of cores drilled at the hole.
 #'  \item \code{date_started}: The date on which drilling commenced.
+#'  \item \code{date_finished}: The date on which drilling concluded.
 #'  \item \code{comments}: Written notes assigned to the core.
-#'  \item \code{ref_id}: The unique identifier of the reference.
+#'  \item \code{ref_id}: The unique identification number of the reference.
 #'  }
 #'  If `sf` is `TRUE`, an `sf` object is returned instead, with a "geometry"
 #'   column that contains the spatial data instead of the `lat`/`lng` columns.
-#'
-#' @author Bethany Allen
+#' @section Developer(s):
+#'   Bethany Allen
+#' @section Reviewer(s):
+#'   Christopher D. Dean
 #' @section References:
 #' Sessa JA, Fraass AJ, LeVay LJ, Jamson KM, and Peters SE. (2023). The
 #' Extending Ocean Drilling Pursuits (eODP) Project: Synthesizing Scientific
@@ -54,14 +59,13 @@
 #' @export
 #' @family external
 def_drilling_sites <- function(program = NULL, exp = NULL, site = NULL,
-    sf = FALSE) {
-
+                               sf = FALSE) {
   # Error handling
   # Collect input arguments as a list
   args <- as.list(environment())
   # Check whether class of arguments is valid
   ref <- list(program = "character", exp = "character", site = "character",
-    sf = "logical"
+              sf = "logical"
   )
   check_arguments(x = args, ref = ref)
   # Recode names

--- a/man/def_drilling_sites.Rd
+++ b/man/def_drilling_sites.Rd
@@ -75,7 +75,7 @@ e2022GC010655. \doi{10.1029/2022GC010655}.
 # Return all core information for a specific site
 core_info <- def_drilling_sites(site = "U1547")
 # Return all core information for a specific expedition
-core_info <- def_drilling_sites(exp = "385")
+core_info <- def_drilling_sites(exp = "317")
 }
 }
 \seealso{

--- a/man/def_drilling_sites.Rd
+++ b/man/def_drilling_sites.Rd
@@ -11,7 +11,7 @@ def_drilling_sites(program = NULL, exp = NULL, site = NULL, sf = FALSE)
 "DSDP", "ODP", or "IODP") to return a definition for.}
 
 \item{exp}{\code{character}. The unique identification number(s) of drilling
-leg(s) to return a definition for.}
+expedition(s) to return a definition for (formerly known as 'leg(s)').}
 
 \item{site}{\code{character}. The unique identification number(s) of drilling
 site(s) to return a definition for.}
@@ -23,24 +23,26 @@ Defaults to \code{FALSE}.}
 A \code{data.frame} object containing, for each retrieved core:
 \itemize{
 \item \code{epoch}: The name of the drilling program.
-\item \code{exp}: The name of the leg/expedition.
+\item \code{leg}: The name of the expedition (formerly known as a 'leg').
 \item \code{site}: The name of the drilling site.
 \item \code{hole}: The name of the drilling hole.
-\item \code{lat}: Decimal degree latitude of the core.
-\item \code{lng}: Decimal degree longitude of the core.
-\item \code{col_id}: The unique identifier of the Macrostrat column.
-\item \code{col_group_id}: The unique identifier of the group to which the
-Macrostrat column belongs.
-\item \code{penetration}: The depth of the hole.
-\item \code{cored}: The amount of rock cored.
-\item \code{recovered}: The amount of rock recovered.
-\item \code{recovery}: The proportion of rock recovered.
+\item \code{lat}: The decimal degree latitude of the drilling hole.
+\item \code{lng}: The decimal degree longitude of the drilling hole.
+\item \code{col_id}: The unique identification number of the eODP column.
+\item \code{col_group_id}: The unique identification number of the group to
+which the eODP column belongs.
+\item \code{penetration}: The depth of the hole drilled, in meters.
+\item \code{cored}: The amount of rock cored from the drill hole, in meters.
+\item \code{recovered}: The amount of rock recovered from the core, in
+meters.
+\item \code{recovery}: The proportion of rock recovered from the core.
 \item \code{drilled_interval}: The interval drilled.
 \item \code{drilled_intervals}: The number of drilled intervals.
-\item \code{cores}: The number of cores.
+\item \code{cores}: The total number of cores drilled at the hole.
 \item \code{date_started}: The date on which drilling commenced.
+\item \code{date_finished}: The date on which drilling concluded.
 \item \code{comments}: Written notes assigned to the core.
-\item \code{ref_id}: The unique identifier of the reference.
+\item \code{ref_id}: The unique identification number of the reference.
 }
 If \code{sf} is \code{TRUE}, an \code{sf} object is returned instead, with a "geometry"
 column that contains the spatial data instead of the \code{lat}/\code{lng} columns.
@@ -50,6 +52,16 @@ Obtain metadata for variables associated with the
 \href{https://eodp.github.io}{Extending Ocean Drilling Pursuits (eODP)} project.
 By default, data for all drilling sites are returned.
 }
+\section{Developer(s)}{
+
+Bethany Allen
+}
+
+\section{Reviewer(s)}{
+
+Christopher D. Dean
+}
+
 \section{References}{
 
 Sessa JA, Fraass AJ, LeVay LJ, Jamson KM, and Peters SE. (2023). The
@@ -72,8 +84,5 @@ External data:
 \code{\link{get_eodp}()},
 \code{\link{get_fossils}()},
 \code{\link{get_measurements}()}
-}
-\author{
-Bethany Allen
 }
 \concept{external}


### PR DESCRIPTION
HI @bethany-j-allen, great job on working your way through this :S I gave things a check and had a read of that Sessa paper, and in light of that made a few minor changes to language. Otherwise looks good; some minor formatting sorted.

However, I did discover that when attempting to select drill cores via the expedition (e.g. def_drilling_sites(exp = "385")), the entire list of expeditions is returned. This is the same case on the Macrostrat API - it just shows {"success":{"v":2,"license":"CC-BY 4.0","data":[]}} and nothing else. However, I CAN get exp 317 to return just that exp, which just so happens to be the example used on the Macrostrat API. I've changed the example to use exp 317 so that it actually returns something sensible, but the majority of users are not going to have that experience. Not sure what you're thoughts on this are, but probably something else that we should flag to the Macrostrat team.

@willgearty @LewisAJones just clueing you in on this too!